### PR TITLE
Localhost issue

### DIFF
--- a/MumbleTester.cs
+++ b/MumbleTester.cs
@@ -38,6 +38,9 @@ public class MumbleTester : MonoBehaviour {
             Debug.LogError("Please set the mumble host name to your mumble server");
             return;
         }
+        
+        if(HostName.ToLower() == "localhost") HostName = "127.0.0.1";
+
         Application.runInBackground = true;
         // If SendPosition, we'll send three floats.
         // This is roughly the standard for Mumble, however it seems that


### PR DESCRIPTION
It's rather a hard fix, I simply added the following line to MumbleTester.cs :
`if(HostName.ToLower() == "localhost") HostName = "127.0.0.1";`

It works fine, although the best solution would be to fix the fact that the adress "0.0.0.1" is automatically selected when "localhost" is written in the HostName field in the inspector.